### PR TITLE
Support prebuilding npm packages as external bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,79 @@
 # rollup-cache
 
 This package provides tools to speed up repeated [Rollup](https://rollupjs.org)
-bundle builds by caching certain steps in the build process to disk.
+bundle builds by caching steps of the build process to disk.
+
+## Comparison to Rollup's built-in caching
 
 Rollup has a built-in cache used to speed up incremental builds in `watch`
 mode. This is an in-memory cache that is lost each time Rollup is restarted
 however. `rollup-cache` speeds up the initial build and builds which do not
-use `watch` mode.
+use `watch` mode by using a disk cache.
 
 ## How it works
 
+This package implements two kinds of caching: **plugin caching** and **prebuilding**.
+
+### Plugin caching
+
 The package adds caching for the loading and transforming of code done by
-certain Rollup plugins. By default it enables caching only for official Rollup
-plugins which are both frequently used and relatively slow.
+Rollup plugins. By default it is enabled only for official Rollup plugins with
+which it is compatible and where it can significantly speed up builds:
+
+- @rollup/plugin-commonjs
+- @rollup/plugin-node-resolve
+- @rollup/plugin-babel
+
+_TODO: Add a note here on how enable caching for other plugins._
+
+### Prebuilding
+
+For every JavaScript module included in a bundle, Rollup has to do work to
+parse the code, analyze the result and write the contents to the output.
+
+For npm dependencies which do not change between most builds, this
+can be avoided by building the npm package into a bundle which is then referenced
+from your application bundle. Conceptually this is similar to shared libraries
+(aka DLLs) in native applications.
+
+For example, supposing you have a Rollup config that builds `output/app.bundle.js`
+from the following entry module:
+
+```js
+import { doComplexThing } from 'big-library';
+
+doComplexThing(...);
+```
+
+Enabling prebuilding of `big-library` would result in the following in the
+output bundle:
+
+```js
+import { doComplexThing } from './npm/big-library.bundle.js';
+
+doComplexThing(...);
+```
+
+The `big-library` package would be bundled as an ES module in `output/npm/big-library.bundle.js`.
+Each time your Rollup build runs, the timestamp of `big-library`'s package.json
+file will be checked and the `big-library.bundle.js` bundle will be rebuilt if
+it has changed.
+
+In order to use this feature, your application or library bundle must be built
+as an ES module (set `output.format` to `es` in the bundle config) and loaded
+using `<script type="module" …>` in your HTML. You will also need to make sure
+that the tool you are using to serve your assets allows the prebuilt bundles
+to be fetched.
 
 ## Installation
+
+If you are using npm:
+
+```sh
+npm install --save-dev rollup-cache
+```
+
+Or for Yarn:
 
 ```sh
 yarn add --dev rollup-cache
@@ -22,8 +81,8 @@ yarn add --dev rollup-cache
 
 ## Usage
 
-To enable caching for a bundle, wrap the configuration for the bundle in a call
-to `cacheBuild`. For example, given a Rollup config file `rollup.config.js`:
+To enable caching for a bundle, wrap its configuration in a call to `cacheBuild`.
+For example, given a Rollup config file `rollup.config.js`:
 
 ```js
 export default {
@@ -33,7 +92,7 @@ export default {
 }
 ```
 
-Change it as follows:
+Caching can be added using:
 
 ```js
 import { cacheBuild } from 'rollup-cache';
@@ -41,6 +100,7 @@ import { cacheBuild } from 'rollup-cache';
 const cacheConfig = {
   name: 'my-app',
   dependencies: ['rollup.config.js'],
+  prebuild: ['big-library'],
 };
 
 export default cacheBuild(cacheConfig, {
@@ -56,24 +116,49 @@ for each bundle.
 If any of the files listed in the `dependencies` option have changed since the
 previous build, then the existing cache will be discarded.
 
-## Cache options
+`prebuild` specifies a list of npm packages to prebuild as separate npm bundles.
+If omitted, prebuilding will be disabled.
+
+## Configuration
+
+### General options
 
 - `name` specifies a unique name for the cache data. This should be different
   for each bundle.
-- `cacheDir` specifies a location to write cache files to. _Default: node_modules/.cache/rollup-cache_
-- `dependencies` is a list of file paths whose contents should be used to
-  determine whether existing cache entries are valid. In addition to the files
-  listed here, the following files are automatically considered:
-
-  - Package manager files listing dependencies: `package.json`, `package-lock.json`,
-    `yarn.lock`
 
 - `enabled` specifies whether caching should be used for the current build.
   By default this is false for production builds, indicated by the `NODE_ENV`
-  environment variable being set to `production`, or true otherwise.
-
-  It is recommended to disable caching for production builds to reduce the risk
+  environment variable being set to `production`, or true otherwise. It is
+  recommended to **disable caching for production builds** to reduce the risk
   of stale cache data being used.
+
+### Plugin caching options
+
+- `cacheDir` specifies a location to write cache files to. _Default: "node_modules/.cache/rollup-cache"_
+
+- `dependencies` is a list of file paths whose contents should be used to
+  determine whether to reuse cached results from previous builds. If any of these
+  files have changed since the previous build, cached data will be ignored. In
+  addition to the files listed here, the following files are automatically
+  included:
+
+  - Package metadata: `package.json`
+  - Lockfiles: `package-lock.json`, `yarn.lock`
+
+### Prebuild options
+
+- `prebuildDir` specifies a directory to create pre-built npm dependencies in,
+  relative to the output directory of the bundle. _Default: "./npm"_
+
+- `prebuild` is a list of npm dependencies or patterns that should be prebuilt
+  if they are used by the bundle. For various reasons prebuilding may not work
+  with all dependencies, and is generally only valuable for large dependencies.
+  Therefore the dependencies to consider for prebuilding have to be listed explicitly.
+
+  The recommended approach to using this option is to start with an empty
+  `prebuild` list and then incrementally add your largest dependencies to it.
+  If you encounter an error building the bundle or loading your application,
+  skip that dependency.
 
 ## Clearing the cache
 

--- a/lib/build-npm-bundles.js
+++ b/lib/build-npm-bundles.js
@@ -1,0 +1,116 @@
+import * as path from "path";
+import { readFileSync, statSync } from "fs";
+
+import commonjs from "@rollup/plugin-commonjs";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
+import * as rollup from "rollup";
+
+/**
+ * @param {string} dir
+ * @param {string} name
+ */
+function bundlePath(dir, name) {
+  return `${dir}/${name}.bundle.js`;
+}
+
+/**
+ * Return the relative path from one ES bundle to another, suitable for
+ * use in an `import` statement.
+ *
+ * @param {string} from
+ * @param {string} to
+ */
+function relativeImportPath(from, to) {
+  const relativePath = path.relative(path.dirname(from), to);
+  if (relativePath.startsWith(".")) {
+    return relativePath;
+  } else {
+    return `./${relativePath}`;
+  }
+}
+
+/**
+ * Return Rollup configuration for bundling an NPM package as an ESM bundle.
+ *
+ * @param {string} name
+ * @param {string} dir
+ * @param {string[]} deps - List of NPM dependencies which are also being prebuilt
+ *   in the current build. This is used to ensure that any common dependencies
+ *   between bundles all refer to the same bundle. eg. For example if building
+ *   an application which depends on React as well as a library of React components,
+ *   both the application and the library must use the same copy of React.
+ * @return {import("rollup").RollupOptions}
+ */
+function bundleConfig(name, dir, deps) {
+  return {
+    input: name,
+    output: {
+      file: bundlePath(dir, name),
+      format: "es",
+      sourcemap: true,
+      paths: Object.fromEntries(
+        deps.map((dep) => [
+          dep,
+          relativeImportPath(bundlePath(dir, name), bundlePath(dir, dep)),
+        ])
+      ),
+    },
+    external: deps.filter((d) => d !== name),
+    plugins: [
+      replace({
+        preventAssignment: true,
+        values: {
+          "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+        },
+      }),
+      nodeResolve(),
+      commonjs({ esmExternals: true }),
+    ],
+  };
+}
+
+/**
+ * Build an NPM dependency as a bundle in `dir`.
+ *
+ * @param {Record<string, number>} npmBundles - Map of npm dependency names to
+ *   timestamps of previous bundle build
+ * @param {string} dir - Directory which bundles should be generated in
+ */
+export async function buildNPMBundles(npmBundles, dir) {
+  const npmBundleList = Object.entries(npmBundles)
+    .filter(([name, timestamp]) => {
+      try {
+        const outputTimestamp = statSync(bundlePath(dir, name)).mtimeMs;
+        if (outputTimestamp >= timestamp) {
+          return false;
+        }
+        return true;
+      } catch (err) {
+        return true;
+      }
+    })
+    .map(([name]) => name)
+    .sort();
+
+  if (npmBundleList.length === 0) {
+    return;
+  }
+
+  console.log(`Building NPM bundles: ${npmBundleList.join(", ")}`);
+
+  const configs = npmBundleList.map((name) =>
+    bundleConfig(name, dir, npmBundleList)
+  );
+  await Promise.all(
+    configs.map(async (config) => {
+      const bundle = await rollup.rollup({
+        ...config,
+        onwarn: console.log,
+      });
+      await bundle.write(
+        /** @type {import("rollup").OutputOptions} */ (config.output)
+      );
+    })
+  );
+}

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,6 +1,19 @@
 import { createHash } from "crypto";
+import { existsSync, readFileSync } from "fs";
 
 import { Cache } from "./cache.js";
+
+/**
+ * @param {string[]} files
+ */
+function createVersionHash(files) {
+  const hash = createHash("md5");
+  for (let file of files) {
+    const data = readFileSync(file);
+    hash.update(data);
+  }
+  return hash.digest("hex");
+}
 
 /**
  * @typedef PluginCacheConfig
@@ -17,7 +30,7 @@ import { Cache } from "./cache.js";
  * @param {PluginCacheConfig} config
  * @return {import("rollup").Plugin}
  */
-export function cachingPlugin(plugin, { cacheDir, versionHash }) {
+function cachingPlugin(plugin, { cacheDir, versionHash }) {
   const cache = new Cache(cacheDir, plugin.name);
 
   /** @param {Buffer|string} data */
@@ -101,7 +114,7 @@ export function cachingPlugin(plugin, { cacheDir, versionHash }) {
 /**
  * @param {{ name: string }} plugin
  */
-export function pluginCacheConfig(plugin) {
+function pluginCacheConfig(plugin) {
   switch (plugin.name) {
     case "babel":
     case "commonjs":
@@ -110,4 +123,46 @@ export function pluginCacheConfig(plugin) {
     default:
       return null;
   }
+}
+
+const defaultDependencies = ["package.json", "package-lock.json", "yarn.lock"];
+
+/**
+ * Wrap a Rollup bundle configuration to enable selective caching of plugin build hooks.
+ *
+ * @param {import("rollup").RollupOptions} buildConfig
+ * @param {object} options
+ *   @param {string} options.cacheRoot
+ *   @param {string[]} options.dependencies
+ */
+export function addPluginCachingToConfig(
+  buildConfig,
+  { cacheRoot, dependencies }
+) {
+  const versionHash = createVersionHash([
+    ...defaultDependencies.filter((path) => existsSync(path)),
+    ...dependencies,
+  ]);
+
+  const cachingPlugins =
+    buildConfig.plugins?.map((plugin) => {
+      if (!plugin) {
+        return plugin;
+      }
+      const config = pluginCacheConfig(plugin);
+      if (!config) {
+        return plugin;
+      }
+      return cachingPlugin(plugin, {
+        cacheDir: cacheRoot,
+        // TODO - Add plugin-specific files (eg. Babel config) to version hash.
+        versionHash,
+        ...config,
+      });
+    }) ?? [];
+
+  return {
+    ...buildConfig,
+    plugins: [...cachingPlugins],
+  };
 }

--- a/lib/prebuild.js
+++ b/lib/prebuild.js
@@ -1,0 +1,166 @@
+import { existsSync, readFileSync, statSync } from "fs";
+import { writeFile } from "fs/promises";
+import { createRequire } from "module";
+import * as path from "path";
+
+import { buildNPMBundles } from "./build-npm-bundles.js";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Return the path of the `package.json` file associated with a given module ID.
+ *
+ * The module ID may be the name of a package or a module within a package,
+ * in which case the containing package's package.json is found.
+ *
+ * @param {string} moduleID
+ */
+function getPackageJSONPath(moduleID) {
+  const entryPoint = require.resolve(moduleID);
+  let dir = path.dirname(entryPoint);
+  let relativePackagePath = "package.json";
+  while (dir !== "/" && !existsSync(`${dir}/${relativePackagePath}`)) {
+    dir = path.dirname(dir);
+  }
+  return `${dir}/${relativePackagePath}`;
+}
+
+/**
+ * Get the last-modified timestamp of the package.json file associated with
+ * a module.
+ *
+ * @param {string} moduleID
+ */
+function getPackageTimestamp(moduleID) {
+  const packagePath = getPackageJSONPath(moduleID);
+  try {
+    const stats = statSync(packagePath);
+    return stats.mtimeMs;
+  } catch (err) {
+    throw new Error(`Failed to get package version for "${moduleID}"`);
+  }
+}
+
+/**
+ * Wrap a Rollup bundle configuration to enable prebuilding of npm dependencies.
+ *
+ * @param {import("rollup").RollupOptions} buildConfig
+ * @param {object} options
+ *   @param {string} options.cacheRoot
+ *   @param {string} options.prebuildDir
+ *   @param {(string|RegExp)[]} options.prebuild
+ */
+export function addPrebuildingToConfig(
+  buildConfig,
+  { cacheRoot, prebuildDir, prebuild }
+) {
+  /**
+   * Module IDs of npm dependencies that have been discovered in this build
+   * that should be prebuilt and marked as external within the output bundle.
+   *
+   * @type {Set<string>}
+   */
+  const externalDependencies = new Set();
+
+  /**
+   * @param {string} id
+   * @param {string|undefined} parentId
+   * @param {boolean} isResolved
+   * @return {boolean}
+   */
+  const shouldMakeExternal = (id, parentId, isResolved) => {
+    if (
+      // Is this a local (non-npm) import?
+      !id.startsWith(".") &&
+      !id.startsWith("/") &&
+      // Is prebuilding enabled for this package?
+      prebuild.some((pattern) => id.match(pattern))
+    ) {
+      externalDependencies.add(id);
+      return true;
+    }
+
+    // Fall back to original external function.
+    // See https://rollupjs.org/guide/en/#external.
+    const origExternal = buildConfig.external;
+    if (!origExternal) {
+      return false;
+    }
+    if (typeof origExternal === "function") {
+      return !!origExternal(id, parentId, isResolved);
+    } else if (Array.isArray(origExternal)) {
+      return origExternal.some((pattern) => id.match(pattern));
+    } else {
+      return !!id.match(origExternal);
+    }
+  };
+
+  /**
+   * @param {string} id
+   * @param {import("rollup").OptionsPaths} [origPaths]
+   */
+  const getOutputPath = (id, origPaths) => {
+    let origPath;
+    if (typeof origPaths === "function") {
+      origPath = origPaths(id);
+    } else if (origPaths) {
+      origPath = origPaths[id];
+    }
+    if (origPath) {
+      return origPath;
+    }
+    if (externalDependencies.has(id)) {
+      return `${prebuildDir}/${id}.bundle.js`;
+    }
+    return id;
+  };
+
+  // TODO - Handle the case where `buildConfig.output` is an array.
+
+  /** @type {import("rollup").OutputOptions} */
+  const output = {
+    ...buildConfig.output,
+    paths: (id) =>
+      getOutputPath(
+        id,
+        /** @type {import("rollup").OutputOptions} */ (buildConfig.output).paths
+      ),
+  };
+
+  let outputDir;
+  if (output.dir) {
+    outputDir = output.dir;
+  } else if (output.file) {
+    outputDir = path.dirname(output.file);
+  } else {
+    throw new Error(
+      `"output.dir" or "output.file" options must be specified in Rollup config to use prebuilding`
+    );
+  }
+
+  const resolvedPrebuildDir = path.resolve(outputDir, prebuildDir);
+
+  const buildExternalDeps = {
+    name: "rollup-cache:build-external-deps",
+
+    async buildEnd() {
+      /** @type {Record<string, number>} */
+      const depVersions = {};
+      const deps = [...externalDependencies].sort();
+      for (let dependency of deps) {
+        depVersions[dependency] = getPackageTimestamp(dependency);
+      }
+      await buildNPMBundles(depVersions, resolvedPrebuildDir);
+    },
+  };
+
+  return {
+    ...buildConfig,
+    output,
+    external: shouldMakeExternal,
+    plugins: [
+      .../** @type {import("rollup").Plugin[]} */ (buildConfig.plugins),
+      buildExternalDeps,
+    ],
+  };
+}

--- a/package.json
+++ b/package.json
@@ -14,12 +14,17 @@
   "devDependencies": {
     "@types/node": "^16.11.6",
     "prettier": "^2.4.1",
-    "rollup": "^2.58.3",
     "typescript": "^4.4.4"
   },
   "scripts": {
     "checkformatting": "prettier --check **/*.js",
     "format": "prettier --write --list-different **/*.js",
     "typecheck": "tsc"
+  },
+  "dependencies": {
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-replace": "^3.0.0",
+    "rollup": "^2.59.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,29 +2,246 @@
 # yarn lockfile v1
 
 
-"@types/node@^16.11.6":
+"@rollup/plugin-commonjs@^21.0.1":
+  version "21.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.1.tgz#1e57c81ae1518e4df0954d681c642e7d94588fee"
+  integrity sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-node-resolve@^13.0.6":
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz#29629070bb767567be8157f575cfa8f2b8e9ef77"
+  integrity sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/plugin-replace@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-3.0.0.tgz#3a4c9665d4e7a4ce2c360cf021232784892f3fac"
+  integrity sha512-3c7JCbMuYXM4PbPWT4+m/4Y6U60SgsnDT/cCyAyUKwFHg7pTSfsSQzIpETha3a3ig6OdOKzZz87D9ZXIK3qsDg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
+"@types/estree@*":
+  version "0.0.50"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
+  integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/node@*", "@types/node@^16.11.6":
   version "16.11.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
   integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+glob@^7.1.6:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+is-core-module@^2.2.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
+  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+  dependencies:
+    has "^1.0.3"
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+  dependencies:
+    wrappy "1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+path-parse@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+picomatch@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
 prettier@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
-rollup@^2.58.3:
-  version "2.58.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.58.3.tgz#71a08138d9515fb65043b6a18618b2ed9ac8d239"
-  integrity sha512-ei27MSw1KhRur4p87Q0/Va2NAYqMXOX++FNEumMBcdreIRLURKy+cE2wcDJKBn0nfmhP2ZGrJkP1XPO+G8FJQw==
+resolve@^1.17.0, resolve@^1.19.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
+rollup@^2.59.0:
+  version "2.59.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.59.0.tgz#108c61b0fa0a37ebc8d1f164f281622056f0db59"
+  integrity sha512-l7s90JQhCQ6JyZjKgo7Lq1dKh2RxatOM+Jr6a9F7WbS9WgKbocyUSeLmZl8evAse7y96Ae98L2k1cBOwWD8nHw==
   optionalDependencies:
     fsevents "~2.3.2"
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 typescript@^4.4.4:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=


### PR DESCRIPTION
Implement opt-in prebundling of npm packages as external bundles. This
is opt-in because there are many packages where it may not work as
expected (eg. due to ambiguity over how to translate CommonJS exports
to ES exports in CommonJS packages) and changes are also likely to be
required in consuming projects to serve the bundles.

In the process of implementing this the existing entry point was
refactored to move most of the plugin caching logic into
`lib/plugin.js`.