### PR TITLE
Add type definitions to package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,5 @@ jobs:
       run: yarn install --frozen-lockfile
     - name: Format
       run: yarn checkformatting
-    - name: Typecheck
-      run: yarn typecheck
+    - name: Build
+      run: yarn build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+types/

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "Caching tools for Rollup",
   "type": "module",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "repository": "https://github.com/robertknight/rollup-cache",
   "author": "Robert Knight <robertknight@gmail.com>",
   "license": "BSD-2-Clause",
   "files": [
     "index.js",
-    "lib/"
+    "lib/",
+    "types/"
   ],
   "devDependencies": {
     "@types/node": "^16.11.6",
@@ -17,9 +19,9 @@
     "typescript": "^4.4.4"
   },
   "scripts": {
+    "build": "tsc",
     "checkformatting": "prettier --check **/*.js",
-    "format": "prettier --write --list-different **/*.js",
-    "typecheck": "tsc"
+    "format": "prettier --write --list-different **/*.js"
   },
   "dependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,9 @@
     "checkJs": true,
 
     /* Emit */
-    "noEmit": true,
+    "outDir": "types",
+    "declaration": true,
+    "emitDeclarationOnly": true,
 
     /* Type Checking */
     "strict": true,


### PR DESCRIPTION
The type information was already present in the code in the form of
JSDoc, but not included in the generated package as .d.ts files for use
by TypeScript in downstream projects.

Fixes #4