### PR TITLE
WIP: Provide CommonJS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 types/
+index-cjs.js

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:cjs": "rollup -c",
     "checkformatting": "prettier --check **/*.js",
     "format": "prettier --write --list-different **/*.js",
     "prepublish": "yarn build"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import("rollup").RollupOptions}
+ */
+export default {
+	input: "index.js",
+	output: {
+		file: "index-cjs.js",
+		format: "cjs",
+		exports: "auto",
+	},
+};


### PR DESCRIPTION
This PR aims to resolve #3.

Currently, Rollup will create a CommonJS bundle from `index.js`.

- But it is not configured to be included in the published package yet. I am not sure how.
- And, I haven't tested it yet.

I hope I can get some help.